### PR TITLE
Develop

### DIFF
--- a/libexec/watcher
+++ b/libexec/watcher
@@ -7,12 +7,19 @@ set -euo pipefail
 process_routes() {
     local domainname selfLink
     local tmpl='.object.spec.host + ":" + .object.metadata.selfLink'
+    
     log "watching routes with selector $LETSENCRYPT_ROUTE_SELECTOR"
+    log "$(watch_routes)"
+    
     watch_routes | jq -er --unbuffered "$tmpl" \
         | while IFS=: read -r domainname selfLink; do
-            log "Processing route $selfLink with domain $domainname."
-            get_certificate "$domainname" "$selfLink"
-        done
+            if [ -n domainname ] && [ -n selfLink ]; then
+              log "Processing route $selfLink with domain $domainname."
+              get_certificate "$domainname" "$selfLink"
+            else
+              log watch_routes
+            fi
+            done
 }
 
 while true

--- a/libexec/watcher
+++ b/libexec/watcher
@@ -9,7 +9,6 @@ process_routes() {
     local tmpl='.object.spec.host + ":" + .object.metadata.selfLink'
     
     log "watching routes with selector $LETSENCRYPT_ROUTE_SELECTOR"
-    log "$(watch_routes)"
     
     watch_routes | jq -er --unbuffered "$tmpl" \
         | while IFS=: read -r domainname selfLink; do
@@ -17,7 +16,7 @@ process_routes() {
               log "Processing route $selfLink with domain $domainname."
               get_certificate "$domainname" "$selfLink"
             else
-              log watch_routes
+              log "$(watch_routes)"
             fi
             done
 }

--- a/share/common.sh
+++ b/share/common.sh
@@ -54,6 +54,7 @@ is_true() {
             ;;
     esac
 }
+
 api_call() {
     local uri="${1##/}"; shift
     curl --fail -sSH "Authorization: Bearer $SA_TOKEN" \
@@ -71,9 +72,11 @@ api_call() {
 watch_routes() {
     local routes_uri
     routes_uri="$(route_uri)?watch"
+
     if [ -n "$LETSENCRYPT_ROUTE_SELECTOR" ]; then
         routes_uri="$routes_uri&labelSelector=$LETSENCRYPT_ROUTE_SELECTOR"
     fi
+
     api_call "$routes_uri" -N
 }
 

--- a/template.yaml
+++ b/template.yaml
@@ -30,7 +30,7 @@ objects:
           env:
           - name: LETSENCRYPT_CONTACT_EMAIL
             value: ${LETSENCRYPT_CONTACT_EMAIL}
-          image: crossb0w/openshift-letsencrypt:latest
+          image: ibotty/openshift-letsencrypt:latest
           imagePullPolicy: Always
           name: watcher
           volumeMounts:
@@ -45,7 +45,7 @@ objects:
           env:
           - name: LETSENCRYPT_CONTACT_EMAIL
             value: ${LETSENCRYPT_CONTACT_EMAIL}
-          image: crossb0w/openshift-letsencrypt:latest
+          image: ibotty/openshift-letsencrypt:latest
           name: cron
           terminationMessagePath: /dev/termination-log
           volumeMounts:

--- a/template.yaml
+++ b/template.yaml
@@ -30,7 +30,7 @@ objects:
           env:
           - name: LETSENCRYPT_CONTACT_EMAIL
             value: ${LETSENCRYPT_CONTACT_EMAIL}
-          image: ibotty/openshift-letsencrypt:latest
+          image: crossb0w/openshift-letsencrypt:latest
           imagePullPolicy: Always
           name: watcher
           volumeMounts:
@@ -45,7 +45,7 @@ objects:
           env:
           - name: LETSENCRYPT_CONTACT_EMAIL
             value: ${LETSENCRYPT_CONTACT_EMAIL}
-          image: ibotty/openshift-letsencrypt:latest
+          image: crossb0w/openshift-letsencrypt:latest
           name: cron
           terminationMessagePath: /dev/termination-log
           volumeMounts:


### PR DESCRIPTION
When you forgot to add the edit role to system:serviceaccount:<namespace>:letsencrypt the watcher script still tries to process an empty list of routes instead of giving a hint about the error.
This solution might be only a temporary fix, but works nice in our environment. ;)